### PR TITLE
fix multistate input #if

### DIFF
--- a/tl_zigbee_sdk/zigbee/zcl/general/zcl_multistate_input.c
+++ b/tl_zigbee_sdk/zigbee/zcl/general/zcl_multistate_input.c
@@ -29,7 +29,7 @@
 #include "../zcl_include.h"
 
 
-#if ZCL_MULTISTATE_INPUT
+#ifdef ZCL_MULTISTATE_INPUT
 /**********************************************************************
  * LOCAL CONSTANTS
  */


### PR DESCRIPTION
fixes this error: `tl_zigbee_sdk/zigbee/zcl/general/zcl_multistate_input.c:32:25: error: #if with no expression`