### PR TITLE
Fix warning for printf

### DIFF
--- a/tl_zigbee_sdk/proj/common/tlPrintf.h
+++ b/tl_zigbee_sdk/proj/common/tlPrintf.h
@@ -57,10 +57,10 @@ int tl_printf(const char *format, ...);
 														}while(0)
 #else
 #if defined(MCU_CORE_826x) || defined(MCU_CORE_8258) || defined(MCU_CORE_8278)
-	#define printf
+	#define printf(...)	
 #endif
 
-	#define TRACE
+	#define TRACE(...)	
 	#define	DEBUG(compileFlag, ...)
 	#define DEBUG_ARRAY(compileFlag, arrayAddr, len)
 #endif


### PR DESCRIPTION
Fix warning: statement with no effect / left-hand operand of comma expression has no effect for non print/debug builds